### PR TITLE
Refactor file path manipulation to be OS-independent

### DIFF
--- a/src/main/kotlin/de/nanogiants/gradle/ext/TaskExt.kt
+++ b/src/main/kotlin/de/nanogiants/gradle/ext/TaskExt.kt
@@ -42,7 +42,7 @@ internal fun Task.addRenameMappingAction(oldOutput: File, newOutput: String, kee
   println(newOutput)
 
   doLast {
-    val newFile = File(oldOutput.absolutePath.replaceAfterLast("/", newOutput))
+    val newFile = File(oldOutput.absolutePath.replaceAfterLast(File.separator, newOutput))
 
     if (oldOutput.exists()) {
       oldOutput.copyTo(newFile, overwrite = true)


### PR DESCRIPTION
Modify the code to use File.separator for replacing the last part of the path, ensuring compatibility across different operating systems like Windows and Unix.

Without this change builds are failing on Windows hosts.